### PR TITLE
Fix how cpx command is invoked

### DIFF
--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -14,7 +14,7 @@
     "prebuild": "mkdirp ../dist || true",
     "build-watch": "npm run prebuild && npm run copy-dependencies && tsc -w --preserveWatchOutput true",
     "build": "npm run prebuild && npm run copy-dependencies && tsc",
-    "copy-dependencies": "cpx ./node_modules/**/* ../dist/node_modules",
+    "copy-dependencies": "cpx \"./node_modules/**/*\" ../dist/node_modules",
     "test": "mocha --require ts-node/register hello-world/**/*.spec.ts",
     "start-api": "concurrently --kill-others --kill-others-on-fail \"npm run build-watch\" \"sam local start-api --template ../template.yaml\""
   },


### PR DESCRIPTION
Without quotation marks around the source, `cpx` breaks and refuses to copy the files. Please see cpx usage example [here](https://www.npmjs.com/package/cpx#example).